### PR TITLE
allow iteration over a reference to the hash table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub struct HashTable<K, V> {
     total_entries: usize,
 }
 
-impl<K: std::hash::Hash + PartialEq, V> Default for HashTable<K, V> {
+impl<K, V> Default for HashTable<K, V> {
     fn default() -> Self {
         let default_number_of_starting_buckets = 10;
         let mut buckets: Vec<Vec<(K, V)>> = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl<'a, K, V> Iterator for HashTableIterator<'a, K, V> {
 mod tests {
     use crate::HashTable;
 
-    #[derive(PartialEq, Debug, Clone)]
+    #[derive(PartialEq, PartialOrd, Debug, Eq, Clone, Ord)]
     struct User {
         name: String,
         age: i32,
@@ -285,7 +285,7 @@ mod tests {
     fn test_iteration_over_hash_table() {
         let mut hash_table = HashTable::with_capacity(9);
 
-        let users = vec![
+        let mut users = vec![
             User {
                 name: "gedalia".to_string(),
                 age: 27,
@@ -316,23 +316,32 @@ mod tests {
             },
         ];
 
-        for user in users {
+        users.sort();
+
+        for user in &users {
             hash_table.insert(user.name.to_string(), user);
         }
 
         for (k, v) in &hash_table {
-            println!("{} {:?}", k, v);
+            let found = &users.binary_search(v);
+            assert!(found.is_ok());
+            assert!(found.map(|i| &users[i].name == k).unwrap() == true);
         }
 
+        let nowhere_man = User {
+            name: String::from("nowhereman"),
+            age: -1,
+        };
+
         // should still be able to use hash table AKA this should compile
-        hash_table.insert(
-            String::from("nowhereman"),
-            User {
+        hash_table.insert(String::from("nowhereman"), &nowhere_man);
+
+        assert_eq!(
+            hash_table.get(&String::from("nowhereman")),
+            Some(&&User {
                 name: String::from("nowhereman"),
                 age: -1,
-            },
+            })
         );
-
-        hash_table.get(&String::from("nowhereman"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,10 @@ impl<'a, K, V> IntoIterator for &'a HashTable<K, V> {
     fn into_iter(self) -> Self::IntoIter {
         let mut buckets_iterator = self.buckets.iter();
         // first elements iterator needs to be initialized
-        let elements_iterator = match buckets_iterator.next() {
-            Some(b) => b.iter(),
-            None => [].iter(),
-        };
+        let elements_iterator = buckets_iterator
+            .next()
+            .map(|bi| bi.iter())
+            .unwrap_or_else(|| [].iter());
         HashTableIterator {
             elements_iterator: Box::new(elements_iterator),
             buckets_iterator: Box::new(buckets_iterator),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,24 +120,17 @@ impl<'a, K, V> Iterator for HashTableIterator<'a, K, V> {
     type Item = &'a (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        // keep going on this bucket
-        // println!("keep going on this bucket");
         self.elements_iterator.next().or_else(|| {
-            // println!("no element available in this bucket; iterating to next bucket and recursing");
+            // no element available in this bucket
+            // iterating to next bucket and either
+            // ending iteration or recursing
             self.current_bucket = self.buckets_iterator.next();
-            let b = match &self.current_bucket {
-                Some(b) => {
-                    // println!("bucket is avaiable");
-                    b
-                }
-                None => {
-                    // println!("no bucket is avaiable");
-                    return None;
-                }
-            };
-            let elements_iterator = b.iter();
-            self.elements_iterator = Box::new(elements_iterator);
-            self.next()
+            self.current_bucket.and_then(|b| {
+                // bucket is available so we are recursing
+                let elements_iterator = b.iter();
+                self.elements_iterator = Box::new(elements_iterator);
+                self.next()
+            })
         })
     }
 }


### PR DESCRIPTION
the result was meant to be as close as possible to
the std lib hash map iteration, but it is different
in that the item returned is a reference to the tuple
and not a reference to a tuple of referenced elements

this implementation is inefficient since it checks buckets
that are empty